### PR TITLE
fix: Handle MsgUnjail transactions

### DIFF
--- a/server/src/account/handler.js
+++ b/server/src/account/handler.js
@@ -15,6 +15,12 @@ export const updateTxToAccounts = async (rawTx, t) => {
   const {
     fromAccount: from, toAccount: to, executed,
   } = rawTx;
+
+  // This function must work only for 'panacea*' accounts (not 'panaceavaloper*' and so on).
+  if (!from.startsWith('panacea1')) { // hrp + '1' (separator)
+    return;
+  }
+
   const fromAccount = await getAccountFromDB(from, t);
   const fromAccountBalance = await requestAccountBalance(from);
   const fromAccountStakingBalance = await requestAccountStakingBalance(from);

--- a/server/src/converter.js
+++ b/server/src/converter.js
@@ -41,6 +41,9 @@ export const txConverter = (data) => {
           toAccount = m.value.to_address;
           amount = m.value.amount ? m.value.amount[0].amount : 0;
           break;
+        case 'cosmos-sdk/MsgUnjail':
+          fromAccount = m.value.address;
+          break;
         case 'aol/MsgCreateTopic':
         case 'aol/MsgAddWriter':
         case 'aol/MsgDeleteWriter':


### PR DESCRIPTION
So far, `MsgUnjail` transactions haven't been handled by Explorer Server.
It has been crashed with the following error:
```
0|npm  |   sql: 'INSERT INTO `transactions` (`blockHeight`,`data`,`executed`,`fromAccount`,`id`,`onChain`,`toAccount`,`txHash`,`blockId`,`createdAt`,`updatedAt`) VALUES (7974433,\'{\\"blockHeight\\":7974433,\\"executed\\":true,\\"fromAccount\\":null,\\"toAccount\\":null,\\"onChain\\":true,\\"txHash\\":\\"5BD51D161A93D8CE5F364BA23A92F3E88A14F4958E1C96AC91E52B58375DC53B:0\\",\\"type\\":\\"cosmos-sdk/MsgUnjail\\",\\"memo\\":\\"\\",\\"amount\\":null}\',true,NULL,NULL,true,NULL,\'5BD51D161A93D8CE5F364BA23A92F3E88A14F4958E1C96AC91E52B58375DC53B:0\',7974433,\'2021-05-24 08:07:22\',\'2021-05-24 08:07:22\');',
0|npm  |   parameters: undefined }
0|npm  | 2021-05-24T08:07:22.885Z [error] : SequelizeDatabaseError: Column 'fromAccount' cannot be null
```

I fixed it to handle `MsgUnjail` properly that looks like below:
```
  "tx": {
    "type": "cosmos-sdk/StdTx",
    "value": {
      "msg": [
        {
          "type": "cosmos-sdk/MsgUnjail",
          "value": {
            "address": "panaceavaloper1j62hw3ylz9sk26staqpa6270sm6qvj6hnzle97"
          }
        }
      ],
      "fee": {
        "amount": [
          {
            "denom": "umed",
            "amount": "1000000"
          }
        ],
        "gas": "200000"
      },
      "signatures": [
        {
          "pub_key": {
            "type": "tendermint/PubKeySecp256k1",
            "value": "A1uck19UHInyY+wqRkyNucuglfUty63aXwk3aKIvRby6"
          },
          "signature": "HzxHpjkui6FbsoWbnWwn+O4e269i8OPGo9o7uJOpcFhVMM/iSoLoPL283Nwrn/0w7ekUUyVsosaLG47Mjjzm7A=="
        }
      ],
      "memo": ""
    }
  },
```

As we know, this code design isn't clean, but we will deprecate this Explorer soon anyway.