### PR TITLE
feat: Display MED supply excluding burned

### DIFF
--- a/client/src/components/LiveTickerWrapper/LiveTickerWrapper.js
+++ b/client/src/components/LiveTickerWrapper/LiveTickerWrapper.js
@@ -5,14 +5,17 @@ import React from 'react';
 import './LiveTickerWrapper.scss';
 
 
-const injectComma = supply => supply.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+// Reference: https://stackoverflow.com/a/2901298
+const injectComma = supply => supply.replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',');
 
 const LiveTickerWrapper = ({
   title,
+  type,
   suffix,
   medxPrice,
   mode,
   totalSupply,
+  totalSupplyExcludingBurned,
   side,
 }) => (
   <div className={cx('liveTickerWrapperGuide', { mobile: mode === 2, [side]: true })}>
@@ -22,7 +25,7 @@ const LiveTickerWrapper = ({
       </div>
       <div className="liveTickerWrapperContent">
         <div>
-          { suffix === 'USD' ? medxPrice.toFixed(5) : injectComma(totalSupply) }
+          { getContent(type, medxPrice, totalSupply, totalSupplyExcludingBurned) }
         </div>
         <div className="liveTickerWrapperContentSuffix">
           {suffix}
@@ -32,18 +35,40 @@ const LiveTickerWrapper = ({
   </div>
 );
 
+export const contentType = {
+  medxPrice: "medxPrice",
+  totalSupply: "totalSupply",
+  totalSupplyExcludingBurned: "totalSupplyExcludingBurned",
+}
+
+function getContent(type, medxPrice, totalSupply, totalSupplyExcludingBurned) {
+  switch (type) {
+    case contentType.medxPrice:
+      return medxPrice.toFixed(5)
+    case contentType.totalSupply:
+      return injectComma(totalSupply)
+    case contentType.totalSupplyExcludingBurned:
+      return injectComma(totalSupplyExcludingBurned)
+    default:
+      return "N/A"
+  }
+}
+
 LiveTickerWrapper.propTypes = {
   medxPrice: PropTypes.number,
   mode: PropTypes.number.isRequired,
   totalSupply: PropTypes.string,
+  totalSupplyExcludingBurned: PropTypes.string,
   side: PropTypes.string.isRequired,
   suffix: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
 };
 
 LiveTickerWrapper.defaultProps = {
   medxPrice: 0,
   totalSupply: '0',
+  totalSupplyExcludingBurned: '0',
 };
 
 export default LiveTickerWrapper;

--- a/client/src/components/LiveTickerWrapper/LiveTickerWrapper.scss
+++ b/client/src/components/LiveTickerWrapper/LiveTickerWrapper.scss
@@ -11,6 +11,10 @@ $tablet-width: 600px;
     margin-right: 40px;
   }
 
+  &.center {
+    justify-content: center;
+  }
+
   &.right {
     margin-left: 40px;
     justify-content: flex-start;
@@ -32,7 +36,7 @@ $tablet-width: 600px;
     }
 
     .liveTickerWrapperContent {
-      font-size: 50px;
+      font-size: 28px;
 
       display: flex;
       flex-wrap: wrap;
@@ -48,7 +52,7 @@ $tablet-width: 600px;
       }
 
       .liveTickerWrapperContentSuffix {
-        font-size: 30px;
+        font-size: 15px;
         font-weight: 100;
         padding-bottom: 5px;
       }
@@ -86,17 +90,17 @@ $tablet-width: 600px;
 
     .liveTickerWrapperTitle {
       //margin: auto;
-      font-size: 16px;
+      font-size: 18px;
       font-weight: 300;
       letter-spacing: -0.4px;
     }
 
     .liveTickerWrapperContent {
       width: 100%;
-      font-size: 30px;
+      font-size: 25px;
 
       .liveTickerWrapperContentSuffix {
-        font-size: 26px;
+        font-size: 18px;
         padding-bottom: 0px;
       }
     }

--- a/client/src/components/LiveTickerWrapper/index.js
+++ b/client/src/components/LiveTickerWrapper/index.js
@@ -1,7 +1,10 @@
 import { connect } from 'react-redux';
 
 import LiveTickerWrapper from './LiveTickerWrapper';
+import BigNumber from "bignumber.js";
 
+// TODO: read this from explorer-server, when it's ready
+const burnedTokens = new BigNumber(268785651.397875);
 
 const mapStateToProps = ({ blockchain, global, ticker }) => ({
   medxPrice: ticker.medxPrice,
@@ -9,6 +12,8 @@ const mapStateToProps = ({ blockchain, global, ticker }) => ({
   mode: global.mode,
 
   totalSupply: blockchain.totalSupply,
+
+  totalSupplyExcludingBurned: new BigNumber(blockchain.totalSupply).minus(burnedTokens).toString(),
 });
 
 export default connect(mapStateToProps)(LiveTickerWrapper);

--- a/client/src/components/TokenInfo/TokenInfo.js
+++ b/client/src/components/TokenInfo/TokenInfo.js
@@ -6,6 +6,7 @@ import { injectIntl, intlShape } from 'react-intl';
 import LiveTickerWrapper from '../LiveTickerWrapper';
 
 import './tokenInfo.scss';
+import { contentType } from "../LiveTickerWrapper/LiveTickerWrapper";
 
 
 const TokenInfo = ({ intl, mode }) => (
@@ -16,14 +17,23 @@ const TokenInfo = ({ intl, mode }) => (
     }
     <LiveTickerWrapper
       title={intl.formatMessage({ id: 'medPrice' })}
+      type={contentType.medxPrice}
       suffix="USD"
       side="left"
     />
     <div className="verticalLine" />
     <LiveTickerWrapper
       title={intl.formatMessage({ id: 'medSupply' })}
+      type={contentType.totalSupply}
       suffix="MED"
-      side="right"
+      side="center"
+    />
+    <div className="verticalLine" />
+    <LiveTickerWrapper
+        title={intl.formatMessage({ id: 'medSupplyExcludingBurned' })}
+        type={contentType.totalSupplyExcludingBurned}
+        suffix="MED"
+        side="right"
     />
   </div>
 );

--- a/client/src/components/TokenInfo/tokenInfo.scss
+++ b/client/src/components/TokenInfo/tokenInfo.scss
@@ -37,6 +37,7 @@ $navBar_height: 85px;
 
   .verticalLine {
     margin-bottom: 60px;
+    height: 70px;
     border-left: 1px solid rgba(255, 255, 255, 0.3);
   }
 }
@@ -44,7 +45,7 @@ $navBar_height: 85px;
 .tokenInfo.mobile {
   margin: auto auto auto -10px;
   width: calc(100% + 20px);
-  height: 200px;
+  height: 300px;
   border-radius: 6px;
   flex-direction: column;
   align-items: center;

--- a/client/src/locale/en.js
+++ b/client/src/locale/en.js
@@ -25,6 +25,7 @@ const en = {
   marketCap: 'Market Cap',
   medPrice: 'MED Price',
   medSupply: 'MED Supply',
+  medSupplyExcludingBurned: 'MED Supply (excluding burned)',
   memo: 'Message (Memo)',
   name: 'Name',
   nonce: 'Nonce',

--- a/client/src/locale/ja.js
+++ b/client/src/locale/ja.js
@@ -25,6 +25,7 @@ const ja = {
   marketCap: '市場価格',
   medPrice: 'MED成行値段',
   medSupply: 'MED総数',
+  medSupplyExcludingBurned: 'MED総数 (excluding burned)',
   memo: 'メッセージ (Memo)',
   name: '名前',
   nonce: 'ナンス',

--- a/client/src/locale/ko.js
+++ b/client/src/locale/ko.js
@@ -25,6 +25,7 @@ const ko = {
   marketCap: '시장 가격',
   medPrice: '메디 시장 가격',
   medSupply: '메디 총 개수',
+  medSupplyExcludingBurned: '메디 총 개수 (소각량 제외)',
   memo: '메시지 (메모)',
   name: '이름',
   nonce: '생성한 거래 수',


### PR DESCRIPTION
Closes #46 

Just added a new `MED Supply (excluding burned)` section.
Although the design isn't fancy, I think it would be okish since we're gonna deprecate this explorer soon (moving to Stamper's).

p.s.
At the first time, I've tried to make it as an annotation (remark) under the `MED Supply` section, but it wasn't simple to align components. Sorry that I'm not a frontend guy :)

![image](https://user-images.githubusercontent.com/5462944/124573932-f4db6380-de84-11eb-874c-30c26d06803b.png)
![image (1)](https://user-images.githubusercontent.com/5462944/124573942-f6a52700-de84-11eb-9a3f-4717c84a7506.png)
